### PR TITLE
implement benchmark for project-4

### DIFF
--- a/project-4/Cargo.toml
+++ b/project-4/Cargo.toml
@@ -27,3 +27,7 @@ rand = "0.6.5"
 tempfile = "3.0.7"
 walkdir = "2.2.7"
 panic-control = "0.1.4"
+
+[[bench]]
+name = "server_benches"
+harness = false

--- a/project-4/benches/server_benches.rs
+++ b/project-4/benches/server_benches.rs
@@ -1,0 +1,81 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kvs_project_4::{thread_pool::*, KvClient, KvServer, KvStore};
+use std::thread;
+use tempfile::TempDir;
+
+const SOCK_ADDR: &'static str = "127.0.0.1:4000";
+const CONCURRENT_CLIENTS: usize = 10;
+
+// construct clients
+// alert: this method doesn't work if server is not up running
+// or server blocks for each connection
+fn construct_clients(num_clients: usize) -> Vec<KvClient> {
+    let mut clients = vec![];
+    for _ in 0..num_clients {
+        let cli = KvClient::new(SOCK_ADDR).expect("Cannot Connect");
+        clients.push(cli);
+    }
+    clients
+}
+
+fn kv_shared_queue_write(c: &mut Criterion) {
+    let threads = [1, 2, 4, 8];
+    let mut group = c.benchmark_group("kv_shared_queue_write");
+
+    for num_thread in threads {
+        let dir = TempDir::new().unwrap();
+        let pool = SharedQueueThreadPool::new(num_thread).unwrap();
+        let store = KvStore::open(dir.path()).unwrap();
+        let server = KvServer::new(SOCK_ADDR, store, pool).unwrap();
+        let shutdown_handle = server.terinate_handle();
+        // get the server running on the other thread
+        let join_handle = thread::spawn(move || {
+            server.run();
+        });
+
+        group.bench_with_input(
+            format!("thread {}", num_thread),
+            &num_thread,
+            |b, _num_thread| {
+                b.iter(move || {
+                    // concurrent send request to server
+                    let clients = construct_clients(CONCURRENT_CLIENTS);
+                    let mut handles = vec![];
+                    for mut client in clients {
+                        let handle = thread::spawn(move || {
+                            for _ in 0..100 {
+                                let response = client
+                                    .send_set("key".to_owned(), "value".to_owned())
+                                    .unwrap();
+                                assert!(response.success);
+                            }
+                            client.shutdown().expect("Cannot Shutdown");
+                        });
+                        handles.push(handle);
+                    }
+
+                    for h in handles {
+                        h.join().unwrap();
+                    }
+                })
+            },
+        );
+
+        // shudtown the server
+        let mut shutdown = shutdown_handle.lock().unwrap();
+        *shutdown = true;
+        drop(shutdown);
+
+        // Now our server is blocking so merely toggle the shutdown
+        // flag is not enough because the server is probably running a blocking
+        // accept method. The workaround is to send a new dummy request to it
+        // to let it finish the last accept call and 'gracefully' terminate
+        let mut dummy_cli = KvClient::new(SOCK_ADDR).unwrap();
+        dummy_cli.sent_get("key".to_owned()).unwrap(); // we don't care if this succeeds or not
+        dummy_cli.shutdown().unwrap();
+        join_handle.join().unwrap();
+    }
+}
+
+criterion_group!(group, kv_shared_queue_write);
+criterion_main!(group);

--- a/project-4/src/bin/kvs-server4.rs
+++ b/project-4/src/bin/kvs-server4.rs
@@ -3,8 +3,7 @@ use kvs_project_4::{thread_pool::*, KvServer, KvStore, SledKvsEngine};
 use std::fmt;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
-use std::path::PathBuf;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::exit;
 use tracing::{info, Level};
 

--- a/project-4/src/network/protocol.rs
+++ b/project-4/src/network/protocol.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use std::io::{BufReader, BufWriter, Cursor, Read, Write};
 use std::net::TcpStream;
 
-pub(crate) fn read<T>(mut reader: BufReader<&TcpStream>) -> Result<T>
+pub(crate) fn read<T>(reader: &mut BufReader<&TcpStream>) -> Result<T>
 where
     T: DeserializeOwned,
 {
@@ -21,7 +21,7 @@ where
     Ok(structure)
 }
 
-pub(crate) fn write<T>(mut writer: BufWriter<&TcpStream>, content: T) -> Result<()>
+pub(crate) fn write<T>(writer: &mut BufWriter<&TcpStream>, content: T) -> Result<()>
 where
     T: Serialize,
 {

--- a/project-4/src/storage/kv_util.rs
+++ b/project-4/src/storage/kv_util.rs
@@ -4,7 +4,7 @@ use serde_json::Deserializer;
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 /// scan the given director, find "<num>.log" file
@@ -83,10 +83,7 @@ pub(super) fn new_log_file(
     Ok(writer)
 }
 
-pub(super) fn open_logfile(
-    dirpath: &Path,
-    gen: u64
-) -> Result<PositionedBufWriter<File>> {
+pub(super) fn open_logfile(dirpath: &Path, gen: u64) -> Result<PositionedBufWriter<File>> {
     let filepath = log_path(dirpath, gen);
     let file = OpenOptions::new()
         .read(true)

--- a/project-4/src/thread_pool/naive.rs
+++ b/project-4/src/thread_pool/naive.rs
@@ -7,7 +7,7 @@ pub struct NaiveThreadPool {}
 
 impl ThreadPool for NaiveThreadPool {
     type Instance = Self;
-    fn new(capacity: i32) -> Result<Self::Instance> {
+    fn new(_capacity: i32) -> Result<Self::Instance> {
         Ok(Self {})
     }
 

--- a/project-4/src/thread_pool/rayon_pool.rs
+++ b/project-4/src/thread_pool/rayon_pool.rs
@@ -1,7 +1,7 @@
 use super::ThreadPool;
 use crate::{KVErrorKind, Result};
 use failure::ResultExt;
-use rayon::{self, prelude::*, ThreadPoolBuilder};
+use rayon::{self, ThreadPoolBuilder};
 
 /// Rayon ThreadPool
 pub struct RayonThreadPool {

--- a/project-4/src/thread_pool/shared_queue.rs
+++ b/project-4/src/thread_pool/shared_queue.rs
@@ -4,7 +4,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use tracing::error;
+use tracing::{error, trace};
 
 trait FnBox {
     fn call_from_box(self: Box<Self>) -> Result<()>;
@@ -97,6 +97,7 @@ impl Drop for SharedQueueThreadPool {
         }
 
         for worker in &mut self.threads {
+            trace!("Dropping Worker {}", worker.id);
             if let Some(handle) = worker.handle.take() {
                 handle.join().unwrap();
             }


### PR DESCRIPTION
Implement benchmark testing throughput of concurrent KvServer. In order to do this, a shutdown flag is added to server. Client also implements a shutdown, too, so that Server's processing threads can return and hence the SharedQueueThreadPool can be dropped.